### PR TITLE
Use `| safe` to prevent double-escaping issues.

### DIFF
--- a/layouts/drc/default.html
+++ b/layouts/drc/default.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/base.html" %}
 
-{% block metaTitle %}{{ deconst.content.envelope.title }}{% endblock %}
+{% block metaTitle %}{{ deconst.content.envelope.title | safe }}{% endblock %}
 {% block content %}
     {{ deconst.content.envelope.body }}
 {% endblock %}

--- a/layouts/drc/default.html
+++ b/layouts/drc/default.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/base.html" %}
 
-{% block metaTitle %}{{ deconst.content.envelope.title | safe }}{% endblock %}
+{% block metaTitle %}{{ deconst.content.envelope.title|safe }}{% endblock %}
 {% block content %}
-    {{ deconst.content.envelope.body | safe }}
+    {{ deconst.content.envelope.body|safe }}
 {% endblock %}

--- a/layouts/drc/default.html
+++ b/layouts/drc/default.html
@@ -2,5 +2,5 @@
 
 {% block metaTitle %}{{ deconst.content.envelope.title | safe }}{% endblock %}
 {% block content %}
-    {{ deconst.content.envelope.body }}
+    {{ deconst.content.envelope.body | safe }}
 {% endblock %}

--- a/layouts/drc/user-guides.html
+++ b/layouts/drc/user-guides.html
@@ -16,12 +16,12 @@
     <div class="serial-links clearfix">
         <div class="previous">
             {% if deconst.content.envelope.previous %}
-                <a href="{{ deconst.content.envelope.previous.url }}">{{ deconst.content.envelope.previous.title | safe }}</a>
+                <a href="{{ deconst.content.envelope.previous.url }}">{{ deconst.content.envelope.previous.title|safe }}</a>
             {% endif %}
         </div>
         <div class="next">
             {% if deconst.content.envelope.next %}
-                <a href="{{ deconst.content.envelope.next.url }}">{{ deconst.content.envelope.next.title | safe }}</a>
+                <a href="{{ deconst.content.envelope.next.url }}">{{ deconst.content.envelope.next.title|safe }}</a>
             {% endif %}
         </div>
     </div>

--- a/layouts/drc/user-guides.html
+++ b/layouts/drc/user-guides.html
@@ -16,12 +16,12 @@
     <div class="serial-links clearfix">
         <div class="previous">
             {% if deconst.content.envelope.previous %}
-                <a href="{{ deconst.content.envelope.previous.url }}">{{ deconst.content.envelope.previous.title }}</a>
+                <a href="{{ deconst.content.envelope.previous.url }}">{{ deconst.content.envelope.previous.title | safe }}</a>
             {% endif %}
         </div>
         <div class="next">
             {% if deconst.content.envelope.next %}
-                <a href="{{ deconst.content.envelope.next.url }}">{{ deconst.content.envelope.next.title }}</a>
+                <a href="{{ deconst.content.envelope.next.url }}">{{ deconst.content.envelope.next.title | safe }}</a>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
This keeps Nunjucks from escaping content that the Sphinx or Jekyll preparers have already escaped, or that are intentionally HTML. It's the equivalent of #39 for the Nunjucks conversion.
